### PR TITLE
Update deps to work on MacOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "sharedbuffer",
+  "name": "shared-buffer",
   "version": "1.0.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "bindings": {
-      "version": "1.2.1",
-      "resolved": "http://localhost:4873/bindings/-/bindings-1.2.1.tgz",
-      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "nan": {
-      "version": "2.6.2",
-      "resolved": "http://localhost:4873/nan/-/nan-2.6.2.tgz",
-      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   "license": "MIT",
   "gypfile": true,
   "dependencies": {
-    "bindings": "^1.2.1",
-    "nan": "^2.6.2"
+    "bindings": "^1.3.0",
+    "nan": "^2.10.0"
   },
-  "repository": { 
-    "type" : "git", 
-    "url" : "https://github.com/voodooattack/shared-buffer.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voodooattack/shared-buffer.git"
   }
 }


### PR DESCRIPTION
Updating the dependancies of this package enabled it to work on MacOS

```bash
$ uname
Darwin
$ npm test

> shared-buffer@1.0.0 test /Users/mkolodny/projects/shared-buffer
> node test.js

Float64Array [
  Infinity,
  1,
  0.5,
  0.3333333333333333,
  0.25,
  0.2,
  0.16666666666666666,
  0.14285714285714285,
  0.125,
  0.1111111111111111 ]
```

While previously on install it would error:  
`../node_modules/nan/nan_maybe_43_inl.h:112:15: error: no member named 'ForceSet' in 'v8::Object'`